### PR TITLE
Light theme as default; restore Facebook activity feed on home

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -54,6 +54,35 @@
 
 <hr class="section-rule" aria-hidden="true">
 
+<section class="activity" aria-labelledby="activity-h">
+  <header class="section-head">
+    <h2 id="activity-h" class="section-title">Cosa succede in questi giorni</h2>
+    <p class="section-sub">Le ultime dalla nostra pagina Facebook — eventi, serate speciali, novità.</p>
+  </header>
+
+  <div class="activity-frame">
+    <iframe
+      class="activity-feed"
+      title="Bacheca Facebook di Just Play Bologna"
+      src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2Fjustplaybologna&tabs=timeline&width=400&height=560&small_header=true&adapt_container_width=true&hide_cover=false&show_facepile=true"
+      width="400"
+      height="560"
+      loading="lazy"
+      style="border:none;overflow:hidden"
+      scrolling="no"
+      allow="encrypted-media"></iframe>
+  </div>
+
+  <p class="activity-fallback">
+    Per il calendario completo, le storie e le foto serali, seguici su
+    <a href="https://www.facebook.com/justplaybologna" target="_blank" rel="noopener">Facebook</a>,
+    <a href="https://www.instagram.com/justplaybologna/" target="_blank" rel="noopener">Instagram</a>
+    o <a href="https://t.me/justplaybologna" target="_blank" rel="noopener">Telegram</a>.
+  </p>
+</section>
+
+<hr class="section-rule" aria-hidden="true">
+
 <section class="where" aria-labelledby="where-h">
   <div class="where-text">
     <header class="section-head">

--- a/src/app/home/home.component.less
+++ b/src/app/home/home.component.less
@@ -151,6 +151,48 @@
   }
 }
 
+// ─── Activity (Facebook page feed) ──────────────────────────────────────────
+// Centered, framed with a paper-deep border so the embed reads as a clipping
+// from a print piece rather than a raw widget. The iframe sizes itself to the
+// FB plugin's native 400×560.
+.activity {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.activity-frame {
+  background: var(--jp-paper-deep);
+  padding: var(--sp-sm);
+  border-radius: var(--jp-radius-md);
+  border: 1px solid var(--jp-rule);
+  align-self: flex-start;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.activity-feed {
+  display: block;
+  width: 400px;
+  max-width: 100%;
+  height: 560px;
+  border-radius: var(--jp-radius-sm);
+  background: #fff;
+}
+
+.activity-fallback {
+  margin-top: var(--sp-lg);
+  font-family: var(--jp-serif);
+  font-size: var(--fs-base);
+  color: var(--jp-ink-soft);
+  max-width: var(--measure);
+}
+
+@media (min-width: 760px) {
+  .activity-frame { align-self: center; }
+  .activity-fallback { align-self: center; text-align: center; }
+}
+
 // ─── Where (asymmetric two-column: text narrow, map wide) ───────────────────
 .where {
   display: grid;

--- a/src/index.html
+++ b/src/index.html
@@ -7,9 +7,8 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- Theme color matches the paper background per scheme so iOS/Android chrome blends. -->
-  <meta name="theme-color" content="#f6efea" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#241917" media="(prefers-color-scheme: dark)">
+  <!-- Theme color matches the paper background. -->
+  <meta name="theme-color" content="#f6efea">
   <meta name="msapplication-TileColor" content="#9b2324">
 
   <!-- Favicon set (existing assets) -->

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -78,13 +78,15 @@ $jp-mat-theme: mat.m2-define-light-theme((
 // NEVER pure black (#000) or pure white (#fff).
 
 :root {
-  color-scheme: light dark;
+  // Light is the only theme. light-dark() values are kept structured below so a
+  // future dark mode can be re-enabled by switching to `color-scheme: light dark`.
+  color-scheme: light;
 
-  // Brand — the Arci red. Same hue across themes; lightness shifts for dark.
+  // Brand — the Arci red.
   --jp-brand-light: oklch(0.45 0.16  27);   // ≈ #9b2324, the soul anchor
-  --jp-brand-dark:  oklch(0.62 0.165 27);   // brighter on felt for AA contrast
+  --jp-brand-dark:  oklch(0.62 0.165 27);   // reserved for a future dark variant
   --jp-brand:       light-dark(var(--jp-brand-light), var(--jp-brand-dark));
-  --jp-brand-ink:   light-dark(#9b2324, #d24c4d);  // legacy alias kept for components
+  --jp-brand-ink:   light-dark(#9b2324, #d24c4d);
 
   // Surfaces
   --jp-paper:       light-dark(oklch(0.97 0.006 27), oklch(0.18 0.012 27));


### PR DESCRIPTION
- color-scheme: light dark -> light. The OS-driven dark variant is off. light-dark() token shape is preserved so dark can be flipped back on by changing only color-scheme + the theme-color meta tag.
- Single theme-color meta (paper warm cream).
- New 'Cosa succede in questi giorni' section between schedule and 'Come arrivare' — restores the FB page plugin (timeline tab) but framed in a paper-deep card so it reads as part of the design system rather than a raw widget. Fallback paragraph below points to FB / IG / Telegram for full calendar.