### PR TITLE
Light/dark toggle: read system pref on first load, persist user choice

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,31 +10,47 @@
       </span>
     </a>
 
-    <nav class="masthead-social" aria-label="I nostri canali social">
-      <a href="https://www.facebook.com/justplaybologna" target="_blank" rel="noopener" aria-label="Facebook">
-        <mat-icon svgIcon="facebook"></mat-icon>
-      </a>
-      <a href="https://www.instagram.com/justplaybologna/" target="_blank" rel="noopener" aria-label="Instagram">
-        <mat-icon svgIcon="instagram"></mat-icon>
-      </a>
-      <a href="https://t.me/justplaybologna" target="_blank" rel="noopener" aria-label="Telegram">
-        <mat-icon svgIcon="telegram"></mat-icon>
-      </a>
-      <a href="https://www.youtube.com/channel/UCNa0SvpXTR_AJ7Tr32N53TQ" target="_blank" rel="noopener" aria-label="YouTube">
-        <mat-icon svgIcon="youtube"></mat-icon>
-      </a>
-      @if (!isSmallScreen) {
-        <a href="https://github.com/JustPlayBo" target="_blank" rel="noopener" aria-label="GitHub">
-          <mat-icon svgIcon="github"></mat-icon>
+    <div class="masthead-end">
+      <nav class="masthead-social" aria-label="I nostri canali social">
+        <a href="https://www.facebook.com/justplaybologna" target="_blank" rel="noopener" aria-label="Facebook">
+          <mat-icon svgIcon="facebook"></mat-icon>
         </a>
-        <a href="https://steamcommunity.com/groups/justplaybo" target="_blank" rel="noopener" aria-label="Steam">
-          <mat-icon svgIcon="steam"></mat-icon>
+        <a href="https://www.instagram.com/justplaybologna/" target="_blank" rel="noopener" aria-label="Instagram">
+          <mat-icon svgIcon="instagram"></mat-icon>
         </a>
-        <a href="https://discord.gg/89R5hpM" target="_blank" rel="noopener" aria-label="Discord">
-          <mat-icon svgIcon="discord"></mat-icon>
+        <a href="https://t.me/justplaybologna" target="_blank" rel="noopener" aria-label="Telegram">
+          <mat-icon svgIcon="telegram"></mat-icon>
         </a>
-      }
-    </nav>
+        <a href="https://www.youtube.com/channel/UCNa0SvpXTR_AJ7Tr32N53TQ" target="_blank" rel="noopener" aria-label="YouTube">
+          <mat-icon svgIcon="youtube"></mat-icon>
+        </a>
+        @if (!isSmallScreen) {
+          <a href="https://github.com/JustPlayBo" target="_blank" rel="noopener" aria-label="GitHub">
+            <mat-icon svgIcon="github"></mat-icon>
+          </a>
+          <a href="https://steamcommunity.com/groups/justplaybo" target="_blank" rel="noopener" aria-label="Steam">
+            <mat-icon svgIcon="steam"></mat-icon>
+          </a>
+          <a href="https://discord.gg/89R5hpM" target="_blank" rel="noopener" aria-label="Discord">
+            <mat-icon svgIcon="discord"></mat-icon>
+          </a>
+        }
+      </nav>
+
+      <button
+        type="button"
+        class="theme-toggle"
+        (click)="toggleTheme()"
+        [attr.aria-label]="theme === 'dark' ? 'Passa al tema chiaro' : 'Passa al tema scuro'"
+        [attr.aria-pressed]="theme === 'dark'"
+        title="Cambia tema">
+        @if (theme === 'dark') {
+          <mat-icon svgIcon="weather-sunny"></mat-icon>
+        } @else {
+          <mat-icon svgIcon="weather-night"></mat-icon>
+        }
+      </button>
+    </div>
   </div>
 
   <div class="container">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -93,12 +93,23 @@
   .brand-tag { display: none; }
 }
 
+// End cluster: social row + theme toggle
+.masthead-end {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-xs);
+  justify-self: end;
+}
+
+@media (max-width: 640px) {
+  .masthead-end { justify-self: start; flex-wrap: wrap; }
+}
+
 // Social row
 .masthead-social {
   display: flex;
   gap: 2px;
   align-items: center;
-  justify-self: end;
 
   a {
     display: inline-flex;
@@ -126,11 +137,53 @@
   .mat-icon svg { height: 20px; width: 20px; }
 }
 
-@media (max-width: 640px) {
-  .masthead-social {
-    justify-self: start;
-    flex-wrap: wrap;
+// ─── Theme toggle ───────────────────────────────────────────────────────────
+// Sun/moon swap with a small rotation so it reads as a flip, not a fade.
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin-left: var(--sp-xs);
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--jp-radius-pill);
+  background: transparent;
+  color: var(--jp-ink-soft);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--easing),
+    background-color var(--dur-fast) var(--easing),
+    border-color var(--dur-fast) var(--easing),
+    transform var(--dur-fast) var(--easing);
+
+  .mat-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform var(--dur-medium) var(--easing);
   }
+  .mat-icon svg { height: 20px; width: 20px; }
+
+  &:hover {
+    color: var(--jp-brand);
+    background: color-mix(in oklab, var(--jp-brand) 8%, transparent);
+    border-color: color-mix(in oklab, var(--jp-brand) 20%, transparent);
+  }
+  &:hover .mat-icon { transform: rotate(-12deg); }
+
+  &:active { transform: scale(0.96); }
+
+  &:focus-visible {
+    outline: 2px solid var(--jp-brand);
+    outline-offset: 2px;
+    color: var(--jp-brand);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .theme-toggle:hover .mat-icon { transform: none; }
 }
 
 // ─── Hand-drawn rule ───────────────────────────────────────────────────────

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,24 +1,82 @@
 import { Component, OnInit } from '@angular/core';
 import { BreakpointObserver } from '@angular/cdk/layout';
 
+type Theme = 'light' | 'dark';
+
 @Component({
-    selector: 'app-root',
-    templateUrl: './app.component.html',
-    styleUrls: ['./app.component.scss'],
-    standalone: false
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss'],
+  standalone: false,
 })
 export class AppComponent implements OnInit {
   title = 'justplaybo-website-new';
   isSmallScreen = false;
+  theme: Theme = 'light';
 
-  constructor(
-    private breakpointObserver: BreakpointObserver
-  ) { }
+  private readonly storageKey = 'jp-theme';
+
+  constructor(private breakpointObserver: BreakpointObserver) {}
 
   ngOnInit() {
-    this.breakpointObserver.observe(['(max-width: 599px)']).subscribe(result => {
+    this.breakpointObserver.observe(['(max-width: 599px)']).subscribe(() => {
       this.isSmallScreen = this.breakpointObserver.isMatched('(max-width: 599px)');
     });
+    this.initTheme();
   }
 
+  toggleTheme() {
+    this.applyTheme(this.theme === 'light' ? 'dark' : 'light', true);
+  }
+
+  private initTheme() {
+    const stored = this.readStoredTheme();
+    if (stored) {
+      this.applyTheme(stored, false);
+      return;
+    }
+    const prefersDark =
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    this.applyTheme(prefersDark ? 'dark' : 'light', false);
+  }
+
+  private applyTheme(theme: Theme, persist: boolean) {
+    this.theme = theme;
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', theme);
+      this.syncThemeColorMeta(theme);
+    }
+    if (persist) {
+      try { localStorage.setItem(this.storageKey, theme); } catch { /* private mode */ }
+    }
+  }
+
+  private readStoredTheme(): Theme | null {
+    try {
+      const v = localStorage.getItem(this.storageKey);
+      return v === 'light' || v === 'dark' ? v : null;
+    } catch { return null; }
+  }
+
+  // Drop the media-conditional theme-color meta tags once the user picks a side
+  // and replace them with a single absolute meta so iOS/Android chrome reflects
+  // the chosen theme even if it disagrees with the OS preference.
+  private syncThemeColorMeta(theme: Theme) {
+    const head = document.head;
+    if (!head) return;
+
+    head.querySelector('#jp-theme-color-light')?.remove();
+    head.querySelector('#jp-theme-color-dark')?.remove();
+
+    let active = head.querySelector<HTMLMetaElement>('#jp-theme-color-active');
+    if (!active) {
+      active = document.createElement('meta');
+      active.name = 'theme-color';
+      active.id = 'jp-theme-color-active';
+      head.appendChild(active);
+    }
+    active.content = theme === 'dark' ? '#241917' : '#f6efea';
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -7,9 +7,25 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <!-- Theme color matches the paper background. -->
-  <meta name="theme-color" content="#f6efea">
+  <!-- Theme color: matches the paper background per scheme so iOS/Android chrome blends.
+       Updated dynamically by AppComponent.toggleTheme() to reflect the user's manual choice. -->
+  <meta name="theme-color" id="jp-theme-color-light" content="#f6efea" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" id="jp-theme-color-dark"  content="#241917" media="(prefers-color-scheme: dark)">
   <meta name="msapplication-TileColor" content="#9b2324">
+
+  <!-- Boot script: applies the saved or system-preferred theme before first paint.
+       Prevents the flash-of-incorrect-theme between HTML load and Angular bootstrap. -->
+  <script>
+    (function () {
+      try {
+        var stored = localStorage.getItem('jp-theme');
+        var theme  = (stored === 'light' || stored === 'dark')
+          ? stored
+          : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) { /* localStorage blocked: fall back to OS preference via CSS */ }
+    })();
+  </script>
 
   <!-- Favicon set (existing assets) -->
   <link rel="apple-touch-icon" sizes="57x57" href="assets/favicon/apple-icon-57x57.png">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -78,9 +78,10 @@ $jp-mat-theme: mat.m2-define-light-theme((
 // NEVER pure black (#000) or pure white (#fff).
 
 :root {
-  // Light is the only theme. light-dark() values are kept structured below so a
-  // future dark mode can be re-enabled by switching to `color-scheme: light dark`.
-  color-scheme: light;
+  // Default: follow OS preference. data-theme overrides force a specific scheme.
+  // The inline boot script in index.html sets data-theme before first paint
+  // (preventing flash); the Angular AppComponent keeps it in sync after.
+  color-scheme: light dark;
 
   // Brand — the Arci red.
   --jp-brand-light: oklch(0.45 0.16  27);   // ≈ #9b2324, the soul anchor
@@ -157,6 +158,10 @@ $jp-mat-theme: mat.m2-define-light-theme((
   // Iconography (MDI sprite)
   --jp-icon-size: 22px;
 }
+
+// User-forced theme overrides (set by the inline boot script + AppComponent).
+:root[data-theme='light'] { color-scheme: light; }
+:root[data-theme='dark']  { color-scheme: dark; }
 
 // ─── Reset + base typography ────────────────────────────────────────────────
 


### PR DESCRIPTION
- :root color-scheme back to 'light dark' (system-driven by default). data-theme='light' / data-theme='dark' attribute overrides force a specific scheme. All existing light-dark() tokens resolve correctly.

- Inline boot script in <head> reads localStorage 'jp-theme', else falls back to prefers-color-scheme, and sets data-theme on <html> BEFORE Angular bootstraps. No flash of incorrect theme on first paint.

- AppComponent owns the in-app state. toggleTheme() flips light <-> dark, persists to localStorage, and rewrites the theme-color meta so iOS/ Android chrome reflects the user's choice (not just OS pref). Initial read covers the case where the boot script ran but Angular wasn't yet alive to pick up the value.

- Toggle UI lives in the masthead end cluster as a 44x44 round button next to the social nav. Sun icon when in dark, moon when in light. Hover tints brand red + 12deg rotation on the icon (suppressed under prefers-reduced-motion). aria-label and aria-pressed update with state.